### PR TITLE
print/exam.php solved wrong page number

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -240,7 +240,7 @@ function emarking_add_instance(stdClass $data, mod_emarking_mod_form $mform = nu
 	} else {
 		$examid = $data->exam;
 	}
-	$studentsnumber = emarking_get_students_count_for_printing ( $COURSE->id );
+	
 	// A new exam object is created and its attributes filled from form data.
 	if ($examid == 0) {
 		$exam = new stdClass ();
@@ -260,7 +260,7 @@ function emarking_add_instance(stdClass $data, mod_emarking_mod_form $mform = nu
 		}
 		$exam->timemodified = time ();
 		$exam->requestedby = $USER->id;
-		$exam->totalstudents = $studentsnumber;
+		
 		$exam->comment = $mform->get_data ()->comment;
 		// Get the enrolments as a comma separated values.
 		$enrollist = array ();
@@ -273,6 +273,10 @@ function emarking_add_instance(stdClass $data, mod_emarking_mod_form $mform = nu
 			}
 		}
 		$exam->enrolments = implode ( ",", $enrollist );
+
+		$studentsnumber = emarking_get_students_count_for_printing ( $COURSE->id, $exam );
+		$exam->totalstudents = $studentsnumber;
+		
 		$exam->printdate = 0;
 		$exam->status = EMARKING_EXAM_UPLOADED;
 		// Calculate total pages for exam.

--- a/print/exam.php
+++ b/print/exam.php
@@ -163,13 +163,11 @@ if ($usercangrade) {
 			emarking_time_ago ( $exam->timecreated ) 
 	);
 
-	//get the actual count of students with the required enrolment
-	$students = emarking_get_students_count_for_printing($course->id, $exam);
-
 	$totalsheetsmessage = new stdClass();
 	$totalsheetsmessage->copies = $exam->totalstudents + $exam->extraexams;
 	$totalsheetsmessage->originals = $exam->totalpages + $exam->extrasheets;
 	$totalsheetsmessage->totalsheets = $totalsheetsmessage->originals * $totalsheetsmessage->copies;
+
 	$examstable->data [] = array (
 			get_string ( 'totalpagesprint', 'mod_emarking'),
 			get_string ( 'totalpagesprintdetails', 'mod_emarking', $totalsheetsmessage)

--- a/print/exam.php
+++ b/print/exam.php
@@ -162,9 +162,13 @@ if ($usercangrade) {
 			get_string ( "sent", "mod_emarking" ),
 			emarking_time_ago ( $exam->timecreated ) 
 	);
+
+	//get the actual count of students with the required enrolment
+	$students = emarking_get_students_count_for_printing($course->id, $exam);
+
 	$totalsheetsmessage = new stdClass();
+	$totalsheetsmessage->copies = $students + $exam->extraexams;
 	$totalsheetsmessage->originals = $exam->totalpages + $exam->extrasheets;
-	$totalsheetsmessage->copies = $exam->totalstudents + $exam->extraexams;
 	$totalsheetsmessage->totalsheets = $totalsheetsmessage->originals * $totalsheetsmessage->copies;
 	$examstable->data [] = array (
 			get_string ( 'totalpagesprint', 'mod_emarking'),

--- a/print/exam.php
+++ b/print/exam.php
@@ -167,7 +167,7 @@ if ($usercangrade) {
 	$students = emarking_get_students_count_for_printing($course->id, $exam);
 
 	$totalsheetsmessage = new stdClass();
-	$totalsheetsmessage->copies = $students + $exam->extraexams;
+	$totalsheetsmessage->copies = $exam->totalstudents + $exam->extraexams;
 	$totalsheetsmessage->originals = $exam->totalpages + $exam->extrasheets;
 	$totalsheetsmessage->totalsheets = $totalsheetsmessage->originals * $totalsheetsmessage->copies;
 	$examstable->data [] = array (


### PR DESCRIPTION
print/exam.php printed the wrong number of pages to be printed as it ignored the required enrollment requirements and just used the amount of people in the course at the moment of the eMarking creation.